### PR TITLE
The drop of ipu-redfish v1.6.4 for Intel® IPU SoC E2100 (MEV-TS) Software 2.1.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -216,7 +216,7 @@ if (ENABLE_TESTS)
 endif()
 
 if(RUN_CLANG_FORMAT)
-  find_program(CLANG_FORMAT "clang-format")
+  find_program(CLANG_FORMAT "clang-format-19")
   if(CLANG_FORMAT)
     file(GLOB_RECURSE FILES_TO_FORMAT
       ${PROJECT_SOURCE_DIR}/application/*.hpp
@@ -228,7 +228,7 @@ if(RUN_CLANG_FORMAT)
     )
     add_custom_target(
       format ALL
-      COMMAND clang-format
+      COMMAND clang-format-19
       -i
       --style=file
       ${FILES_TO_FORMAT}

--- a/application/include/psme/ipu/acc_boot_override_handler.hpp
+++ b/application/include/psme/ipu/acc_boot_override_handler.hpp
@@ -105,6 +105,14 @@ private:
     void clear_memory_reservation_for_iso();
 
     /*!
+     * @brief Ensures that FW will notice the memory reservation for ACC ISO boot.
+     * This function implemnts a workaround for the fact that FW ignores
+     * the BMD configuration override if the "current" (requested) boot option
+     * is the same as the "active" (previously requested) boot option.
+     * */
+    void ensure_memory_reservation_active();
+
+    /*!
      * @brief Removes ISO symlink.
      * */
     void remove_iso_symlink();

--- a/application/include/psme/ipu/ipu_constants.hpp
+++ b/application/include/psme/ipu/ipu_constants.hpp
@@ -22,6 +22,7 @@ extern const char* ERROR;
 extern const char* IP_VERSION;
 extern const char* VPORT_ID;
 extern const char* NONE;
+extern const char* ACTIVE_BOOT_OPTION;
 extern const char* CURRENT_BOOT_OPTION;
 extern const char* DESTINATION_PLDM_FILEPATH;
 extern const char* PLDM_FILE_FOLDER;

--- a/application/src/ipu/ipu_constants.cpp
+++ b/application/src/ipu/ipu_constants.cpp
@@ -13,6 +13,7 @@ const char* ERROR = "Error";
 const char* IP_VERSION = "IpVersion";
 const char* VPORT_ID = "VPortId";
 const char* NONE = "None";
+const char* ACTIVE_BOOT_OPTION = "active_boot_option";
 const char* CURRENT_BOOT_OPTION = "current_boot_option";
 const char* DOWNLOADED_IMAGE_NAME = "DownloadedImageName";
 const char* IMAGE_TEMP_FOLDER = "/tmp/";

--- a/libs/agent-framework/discovery/src/builders/ethernet_interface_builder.cpp
+++ b/libs/agent-framework/discovery/src/builders/ethernet_interface_builder.cpp
@@ -26,9 +26,8 @@ using namespace agent_framework;
 using namespace agent_framework::discovery;
 
 model::NetworkInterface EthernetInterfaceBuilder::build_default(const Uuid& parent_uuid) {
-    model::NetworkInterface interface {
-        parent_uuid
-    };
+    model::NetworkInterface interface{
+        parent_uuid};
     interface.set_status({model::enums::State::Enabled, model::enums::Health::OK});
     return interface;
 }

--- a/libs/agent-framework/tests/module/obj_reference_test.cpp
+++ b/libs/agent-framework/tests/module/obj_reference_test.cpp
@@ -88,7 +88,7 @@ TEST_F(ObjReferenceTest, OtherThreadIsBlockedUntilObjReferenceIsReleased) {
         // thread might be started with some delay
         std::this_thread::sleep_for(std::chrono::milliseconds(100));
         ASSERT_FALSE(mgr.res.thread_touched); // thread is expected to be blocked
-    }                                         // RAII - mutex is released
+    } // RAII - mutex is released
 
     if (t->joinable()) {
         t->join();

--- a/libs/database/src/file_database.cpp
+++ b/libs/database/src/file_database.cpp
@@ -383,7 +383,7 @@ bool FileDatabase::save_file(const std::string& file_name, const std::string& da
     }
 
     /* check current mode of the file */
-    struct stat stats {};
+    struct stat stats{};
     if (0 != fstat(file_descriptor, &stats)) {
         log_error("db", "Cannot set mode for " << file_name << ":: " << strerror(errno));
         return false;


### PR DESCRIPTION
The commit drops the ipu-redfish v1.6.4 for Intel® IPU SoC E2100 (MEV-TS) Software 2.1.0